### PR TITLE
issue #82 refac: remove moreModal recoil state

### DIFF
--- a/src/components/Planning/Calendar/Calendar.style.ts
+++ b/src/components/Planning/Calendar/Calendar.style.ts
@@ -7,7 +7,6 @@ export const containerStyle = css({
 });
 
 export const boxStyle = css({
-	position: "relative",
 	margin: "0 auto",
 	display: "grid",
 	gridGap: "1px",

--- a/src/components/Planning/Calendar/Calendar.tsx
+++ b/src/components/Planning/Calendar/Calendar.tsx
@@ -17,7 +17,6 @@ import {
 
 import { Box } from "@/components/common";
 import CalendarCard from "@/components/Planning/Calendar/CalendarCard/CalendarCard";
-import MoreModal from "@/components/Planning/Calendar/CalendarCard/MoreModal/MoreModal";
 import CalendarHeader from "@/components/Planning/Calendar/CalendarHeader/CalendarHeader";
 import { scheduleModalSelector } from "@/recoil/selectors/modalSelector";
 
@@ -141,9 +140,7 @@ const Calendar = () => {
 					day={day}
 					schedules={daySchedulesWithPosition}
 					position={position}
-				>
-					<MoreModal day={day} schedules={daySchedules} position={position} />
-				</CalendarCard>
+				/>
 			);
 		});
 	}, [currentMonth]);

--- a/src/components/Planning/Calendar/CalendarCard/CalendarCard.tsx
+++ b/src/components/Planning/Calendar/CalendarCard/CalendarCard.tsx
@@ -1,12 +1,11 @@
 import type { PropsWithChildren } from "react";
 
-import { useRecoilState } from "recoil";
-
 import { format, isSameDay } from "date-fns";
 
 import { Box, Flex, Text } from "@/components/common";
+import MoreButton from "@/components/Planning/Calendar/CalendarCard/MoreModal/MoreButton";
+import MoreModal from "@/components/Planning/Calendar/CalendarCard/MoreModal/MoreModal";
 import ScheduleModal from "@/components/Planning/Calendar/CalendarCard/ScheduleModal/ScheduleModal";
-import { moreModalSelector } from "@/recoil/selectors/modalSelector";
 
 import { MAX_CALENDAR_CONTENT } from "@/constants/calendar";
 
@@ -17,8 +16,6 @@ import type { CalendarCardType, ScheduleType } from "@/types/planning";
 import {
 	dateTextStyle,
 	flexStyle,
-	moreBoxStyle,
-	moreTextStyle,
 	scheduleFlexBox,
 	scheduleTextStyle,
 	weekdayTextStyle,
@@ -27,21 +24,15 @@ import {
 const weekday = ["월", "화", "수", "목", "금", "토", "일"];
 
 const CalendarCard = ({
-	index,
 	day,
 	isSameMonth,
 	schedules,
-	children,
 	position,
 }: PropsWithChildren<CalendarCardType>) => {
-	const [isMoreOpen, setIsMoreOpen] = useRecoilState(moreModalSelector);
+	const { index } = position;
 	const { openScheduleModal } = useModal();
 	const schedulesSlice = schedules.slice(0, MAX_CALENDAR_CONTENT);
 	const dayString = format(day, "d");
-
-	const handleMoreOnClick = () => {
-		setIsMoreOpen({ day: dayString });
-	};
 
 	const handleScheduleOnclick = (schedule: ScheduleType) => {
 		openScheduleModal({
@@ -49,7 +40,6 @@ const CalendarCard = ({
 			component: () => <ScheduleModal schedule={schedule} position={position} />,
 		});
 	};
-
 	return (
 		<Flex tag="section" css={flexStyle}>
 			<Text css={weekdayTextStyle}>{index < 7 ? weekday[index] : ""}</Text>
@@ -65,12 +55,9 @@ const CalendarCard = ({
 					</Box>
 				))}
 				{schedules.length > 2 && (
-					<Box css={moreBoxStyle}>
-						<Text css={moreTextStyle} size="xSmall" onClick={handleMoreOnClick}>
-							{schedules.length - 2}개 더보기
-						</Text>
-						{isMoreOpen.day === dayString && children}
-					</Box>
+					<MoreButton schedules={schedules}>
+						<MoreModal day={day} schedules={schedules} position={position} />
+					</MoreButton>
 				)}
 			</Flex>
 		</Flex>

--- a/src/components/Planning/Calendar/CalendarCard/MoreModal/MoreButton.style.ts
+++ b/src/components/Planning/Calendar/CalendarCard/MoreModal/MoreButton.style.ts
@@ -1,0 +1,15 @@
+import { css } from "@emotion/react";
+
+import { Theme } from "@/styles/Theme";
+
+export const moreTextStyle = css({
+	cursor: "pointer",
+	marginLeft: "16px",
+});
+
+export const moreBoxStyle = css({
+	position: "relative",
+	color: Theme.color.text,
+	fontSize: Theme.text.xSmall.fontSize,
+	lineHeight: Theme.text.xSmall.lineHeight,
+});

--- a/src/components/Planning/Calendar/CalendarCard/MoreModal/MoreButton.tsx
+++ b/src/components/Planning/Calendar/CalendarCard/MoreModal/MoreButton.tsx
@@ -1,0 +1,60 @@
+import type { PropsWithChildren } from "react";
+import { useRef } from "react";
+import { useContext } from "react";
+import { createContext } from "react";
+import { useState } from "react";
+
+import { Box, Text } from "@/components/common";
+
+import useClickOutSide from "@/hooks/useClickOutSide";
+
+import type { ScheduleType } from "@/types/planning";
+
+import {
+	moreBoxStyle,
+	moreTextStyle,
+} from "@/components/Planning/Calendar/CalendarCard/MoreModal/MoreButton.style";
+export const tempModalProvider = createContext<{
+	modalValue: boolean;
+	toggleButton: () => void;
+}>({ modalValue: false, toggleButton: () => {} });
+
+const ModalBox = ({ children }: PropsWithChildren) => {
+	const { modalValue } = useContext(tempModalProvider);
+	if (!modalValue) return null;
+	return <Box>{children}</Box>;
+};
+
+interface TempButtonProps {
+	schedules: ScheduleType[];
+}
+
+const MoreButton = ({ schedules, children }: PropsWithChildren<TempButtonProps>) => {
+	const [modalValue, setModalValue] = useState(false);
+
+	const toggleButton = () => {
+		setModalValue((prev) => !prev);
+	};
+
+	const tempModalClose = () => {
+		setModalValue(false);
+	};
+
+	const tempButtonRef = useRef(null);
+
+	useClickOutSide(tempButtonRef, tempModalClose);
+	return (
+		<section ref={tempButtonRef}>
+			<Box css={moreBoxStyle}>
+				<tempModalProvider.Provider value={{ toggleButton, modalValue }}>
+					<Text size="xSmall" onClick={toggleButton} css={moreTextStyle}>
+						{schedules.length - 2}개 더보기
+					</Text>
+					<ModalBox>{children}</ModalBox>
+				</tempModalProvider.Provider>
+			</Box>
+		</section>
+	);
+};
+
+export default MoreButton;

--- a/src/components/Planning/Calendar/CalendarCard/MoreModal/MoreModal.tsx
+++ b/src/components/Planning/Calendar/CalendarCard/MoreModal/MoreModal.tsx
@@ -1,16 +1,12 @@
 import { useRef } from "react";
 
-import { useResetRecoilState } from "recoil";
-
 import { format } from "date-fns";
 
 import { Box, Flex, Text } from "@/components/common";
 import ScheduleModal from "@/components/Planning/Calendar/CalendarCard/ScheduleModal/ScheduleModal";
-import { moreModalSelector } from "@/recoil/selectors/modalSelector";
 
 import { MAX_CALENDAR_CONTENT } from "@/constants/calendar";
 
-import useClickOutSide from "@/hooks/useClickOutSide";
 import useModal from "@/hooks/useModal";
 
 import type { MoreModalType } from "@/types/modal";
@@ -28,18 +24,14 @@ const Week = ["일", "월", "화", "수", "목", "금", "토"];
 
 const MoreModal = ({ day, schedules, position }: MoreModalType) => {
 	const { openScheduleModal } = useModal();
-	const closeMoreModal = useResetRecoilState(moreModalSelector);
 	const moreModalRef = useRef<HTMLDivElement>(null);
 
 	const handleScheduleOnclick = (schedule: ScheduleType) => {
-		closeMoreModal();
 		openScheduleModal({
 			key: format(day, "d"),
 			component: () => <ScheduleModal schedule={schedule} position={position} />,
 		});
 	};
-
-	useClickOutSide(moreModalRef, closeMoreModal);
 
 	const schedulesSlice = schedules.slice(MAX_CALENDAR_CONTENT);
 	return (

--- a/src/recoil/atoms/modal.ts
+++ b/src/recoil/atoms/modal.ts
@@ -1,20 +1,18 @@
 import { atom } from "recoil";
 
-import type { ModalType, MoreModalStateType } from "@/types/modal";
+import type { ModalType } from "@/types/modal";
 
 export const modalState = atom<ModalType[]>({
 	key: "modalState",
 	default: [],
 });
 
-export const moreModalState = atom<MoreModalStateType>({
-	key: "moreModalState",
-	default: {
-		day: null,
-	},
-});
-
 export const scheduleModalState = atom<ModalType[]>({
 	key: "scheduleModalState",
 	default: [],
+});
+
+export const tempModalState = atom<boolean>({
+	key: "tempModalState",
+	default: false,
 });

--- a/src/recoil/selectors/modalSelector.ts
+++ b/src/recoil/selectors/modalSelector.ts
@@ -1,18 +1,8 @@
 import { selector } from "recoil";
 
-import { moreModalState, scheduleModalState } from "@/recoil/atoms/modal";
+import { scheduleModalState } from "@/recoil/atoms/modal";
 
-import type { ModalType, MoreModalStateType } from "@/types/modal";
-
-export const moreModalSelector = selector<MoreModalStateType>({
-	key: "moreModalSelector",
-	get: ({ get }) => {
-		return get(moreModalState);
-	},
-	set: ({ set }, newValue) => {
-		set(moreModalState, newValue);
-	},
-});
+import type { ModalType } from "@/types/modal";
 
 export const scheduleModalSelector = selector<ModalType[]>({
 	key: "scheduleModalSelector",


### PR DESCRIPTION
# 설명

- [https://github.com/teamWaggle/Waggle-front/issues/84](https://github.com/teamWaggle/Waggle-front/issues/84)
- moreModal 에서 누를때 마다 모든 날짜에서 리렌더링이 일어나는 현상을 발견해서 Recoil로 modal state를 관리하지 않고 useState로 관리 했습니다.
- scheduleModal은 확인해본 결과 리펙토링해도 유의미한 결과가 나올것 같지는 않아서 추후에 생각해봐야 할 것 같아요

# 성능 향상
- 43ms -> 7ms